### PR TITLE
fix: rename default region constants

### DIFF
--- a/src/app/components/address-autocomplete/address-autocomplete.component.ts
+++ b/src/app/components/address-autocomplete/address-autocomplete.component.ts
@@ -15,7 +15,7 @@ import {
 import { addIcons } from 'ionicons';
 import { chevronDownCircle, closeCircle, searchOutline } from 'ionicons/icons';
 import { map } from 'rxjs';
-import { DEFOULT_REGION } from 'src/app/constants/defoult.values';
+import { DEFAULT_REGION } from 'src/app/constants/default.values';
 
 @Component({
   selector: 'app-address-autocomplete',
@@ -53,9 +53,9 @@ export class AddressAutocompleteComponent  implements OnInit, OnDestroy {
 
 
   addressForm = new FormGroup({
-    country: new FormControl(DEFOULT_REGION.country, { nonNullable: true }),
-    region: new FormControl(DEFOULT_REGION.region, { nonNullable: true }),
-    city: new FormControl(DEFOULT_REGION.city, { nonNullable: true }),
+    country: new FormControl(DEFAULT_REGION.country, { nonNullable: true }),
+    region: new FormControl(DEFAULT_REGION.region, { nonNullable: true }),
+    city: new FormControl(DEFAULT_REGION.city, { nonNullable: true }),
     street: new FormControl('', { nonNullable: true, validators: [Validators.required]}  ),
     confirmedStreet: new FormControl('', { nonNullable: true, validators: [Validators.required] }  ),
     house: new FormControl('', { nonNullable: true, validators: [Validators.required] }),

--- a/src/app/constants/default.values.ts
+++ b/src/app/constants/default.values.ts
@@ -1,6 +1,6 @@
 import { Address } from "../models/address.model";
 
-export const DEFOULT_REGION: Partial<Address> = {
+export const DEFAULT_REGION: Partial<Address> = {
   city: 'Ужгород',
   country: 'Україна',
   region: 'Закарпатье'

--- a/src/app/home/visits/document-detail/document-detail.page.ts
+++ b/src/app/home/visits/document-detail/document-detail.page.ts
@@ -29,7 +29,7 @@ import { Router } from '@angular/router';
 import { select, Store } from '@ngrx/store';
 import { selectVisitOnEditId, selectVisitWithGoods } from 'src/app/state/documents/doc.selectors';
 import { FormVisit, Visit } from 'src/app/models/visit.model';
-import { DEFOULT_REGION } from 'src/app/constants/defoult.values';
+import { DEFAULT_REGION } from 'src/app/constants/default.values';
 import * as DocsActions from '../../../state/documents/doc.actions';
 import { Address } from 'src/app/models/address.model';
 @Component({
@@ -217,9 +217,9 @@ export class DocumentDetailPage implements OnInit {
       contract: value.contract,
       goods: value.goods,
       visitAddress: {
-        country: DEFOULT_REGION.country,
-        region: DEFOULT_REGION.region,
-        city: DEFOULT_REGION.city,
+        country: DEFAULT_REGION.country,
+        region: DEFAULT_REGION.region,
+        city: DEFAULT_REGION.city,
         street: value.street,
         confirmedStreet: value.confirmedStreet,
         house: value.house,


### PR DESCRIPTION
## Summary
- rename defoult.values.ts to default.values.ts
- rename DEFOULT_REGION export to DEFAULT_REGION
- update imports in address-autocomplete and document-detail components

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform. Please set "CHROME_BIN" env variable.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aee360c50832c81f960da66082792