### PR TITLE
Fix parent loop termination

### DIFF
--- a/src/app/state/goods.selectors.spec.ts
+++ b/src/app/state/goods.selectors.spec.ts
@@ -1,0 +1,21 @@
+import { selectFolderTree } from './goods.selectors';
+import { Good } from '../models/good-model';
+
+describe('Goods selectors', () => {
+  it('should exit loop when parent does not exist', () => {
+    const goodsDictionary: { [id: string]: Good } = {
+      '1': {
+        id: '1',
+        updatedAt: 0,
+        parentid: '2',
+        name: 'child',
+        isFolder: true,
+        normalizedName: 'child'
+      }
+    };
+
+    const selector = selectFolderTree('1');
+    const result = selector.projector(goodsDictionary);
+    expect(result).toEqual([goodsDictionary['1']]);
+  });
+});

--- a/src/app/state/goods.selectors.ts
+++ b/src/app/state/goods.selectors.ts
@@ -36,7 +36,7 @@ export const selectFolderTree = (id: string) =>
         //folderTree.push(currentParent);
         parentID = currentParent.parentid;
       } else {
-        parentID === '';
+        parentID = '';
       }
     }
     return folderTree;


### PR DESCRIPTION
## Summary
- prevent infinite loop when parent not found in selectFolderTree
- add selector test ensuring loop exits without parent

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689af0da765c832c9949e1aa4793919c